### PR TITLE
LicensePlate: Allow access to normalized value (even for invalid values)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .project
 .settings/
 /nbproject/
+.idea/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Contargo Types
 ===============
 
 ## v0.6.3 (Release on xxxx-xx-xx)
+* `LicensePlate`: Allow access to normalized value. It is even available, when it doesn't represent a valid `LicensePlate`. 
 
 ## v0.6.2 (Release on 2017-08-28)
 

--- a/src/main/java/net/contargo/types/truck/LicensePlate.java
+++ b/src/main/java/net/contargo/types/truck/LicensePlate.java
@@ -11,18 +11,34 @@ import net.contargo.types.util.Assert;
  */
 public final class LicensePlate {
 
-    private final String value;
-    private Country country;
+    private final String normalizedValue;
+    private final Country country;
+    private final boolean isValid;
 
     /**
      * Use {@link #forValue(String)} to build a new {@link LicensePlate} instance.
      *
      * @param  value  represents a license plate
+     * @param  country  the {@link Country} where the license plate is registered
      */
-    private LicensePlate(String value) {
+    private LicensePlate(String value, Country country) {
 
-        this.value = value;
+        this.normalizedValue = normalize(country, value);
+        this.country = country;
+        this.isValid = validate(country, normalizedValue);
     }
+
+    private static String normalize(Country country, String rawValue) {
+
+        return country.getLicensePlateHandler().normalize(rawValue);
+    }
+
+
+    private static boolean validate(Country country, String value) {
+
+        return country.getLicensePlateHandler().validate(value);
+    }
+
 
     /**
      * Build a new {@link LicensePlate} with a {@link String} value.
@@ -47,11 +63,7 @@ public final class LicensePlate {
     @Override
     public String toString() {
 
-        if (isValid()) {
-            return country.getLicensePlateHandler().normalize(value);
-        }
-
-        return value;
+        return normalizedValue;
     }
 
 
@@ -62,7 +74,7 @@ public final class LicensePlate {
      */
     public boolean isValid() {
 
-        return country.getLicensePlateHandler().validate(value);
+        return isValid;
     }
 
 
@@ -105,11 +117,11 @@ public final class LicensePlate {
 
     public static class LicensePlateBuilder {
 
-        private LicensePlate licensePlate;
+        private String value;
 
         private LicensePlateBuilder(String value) {
 
-            this.licensePlate = new LicensePlate(value);
+            this.value = value;
         }
 
         /**
@@ -125,9 +137,7 @@ public final class LicensePlate {
 
             Assert.notNull(country, "Country must not be null");
 
-            licensePlate.country = country;
-
-            return licensePlate;
+            return new LicensePlate(value, country);
         }
     }
 }

--- a/src/test/java/net/contargo/types/truck/LicensePlateTest.java
+++ b/src/test/java/net/contargo/types/truck/LicensePlateTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import org.mockito.Mockito;
 
+import static org.mockito.Mockito.when;
+
 
 /**
  * @author  Aljona Murygina - murygina@synyx.de
@@ -67,32 +69,29 @@ public class LicensePlateTest {
         String value = "foo";
         String normalizedValue = "formatted";
 
-        Mockito.when(handlerMock.validate(Mockito.anyString())).thenReturn(true);
-        Mockito.when(handlerMock.normalize(Mockito.anyString())).thenReturn(normalizedValue);
+        when(handlerMock.validate(Mockito.anyString())).thenReturn(true);
+        when(handlerMock.normalize(Mockito.anyString())).thenReturn(normalizedValue);
 
         LicensePlate licensePlate = LicensePlate.forValue(value).withCountry(country);
 
         Assert.assertEquals("Wrong String representation", normalizedValue, licensePlate.toString());
-        Mockito.verify(handlerMock).validate(value);
-        Mockito.verify(handlerMock).normalize(value);
     }
 
 
     @Test
-    public void ensureInvalidLicensePlateIsNotFormatted() {
+    public void ensureInvalidLicensePlateIsFormattedOnToString() {
 
         LicensePlateHandler handlerMock = Mockito.mock(LicensePlateHandler.class);
         Country country = new DummyCountry(handlerMock);
 
-        String value = "foo";
-
-        Mockito.when(handlerMock.validate(Mockito.anyString())).thenReturn(false);
+        String value = "fo-o ";
+        String normalizedValue = "foo";
+        when(handlerMock.normalize(value)).thenReturn(normalizedValue);
 
         LicensePlate licensePlate = LicensePlate.forValue(value).withCountry(country);
 
-        Assert.assertEquals("Wrong String representation", value, licensePlate.toString());
-        Mockito.verify(handlerMock).validate(value);
-        Mockito.verify(handlerMock, Mockito.never()).normalize(value);
+        Assert.assertEquals("Wrong String representation", normalizedValue, licensePlate.toString());
+        Mockito.verify(handlerMock).normalize(value);
     }
 
 
@@ -106,12 +105,32 @@ public class LicensePlateTest {
         Country country = new DummyCountry(handlerMock);
         String value = "foo";
 
-        Mockito.when(handlerMock.validate(Mockito.anyString())).thenReturn(true);
+        when(handlerMock.normalize(value)).thenReturn(value);
+        when(handlerMock.validate(Mockito.anyString())).thenReturn(true);
 
         LicensePlate licensePlate = LicensePlate.forValue(value).withCountry(country);
 
         Assert.assertTrue("Should be valid", licensePlate.isValid());
         Mockito.verify(handlerMock).validate(value);
+    }
+
+
+    @Test
+    public void ensureHandlerForCountryIsCalledOnlyOnceOnIsValid() {
+
+        LicensePlateHandler handlerMock = Mockito.mock(LicensePlateHandler.class);
+        Country country = new DummyCountry(handlerMock);
+        String value = "foo";
+
+        when(handlerMock.normalize(value)).thenReturn(value);
+        when(handlerMock.validate(Mockito.anyString())).thenReturn(true);
+
+        LicensePlate licensePlate = LicensePlate.forValue(value).withCountry(country);
+
+        Assert.assertTrue("Should be valid", licensePlate.isValid());
+        Assert.assertTrue("Should be valid", licensePlate.isValid());
+        Assert.assertTrue("Should be valid", licensePlate.isValid());
+        Mockito.verify(handlerMock, Mockito.times(1)).validate(value);
     }
 
 


### PR DESCRIPTION
For LicensePlates only the normalized value is now accessible to users (via #toString), i.e. this is also done for LicensePlates that are not valid.

This allows users of this class to continue working with the normalized version of the LicensePlate, e.g. for searches in a database.

The class was also made immutable, which allows precomputing the normalized value and the validation state.