### PR TITLE
Validator now also allows a 0 on a digit.

### DIFF
--- a/src/main/java/net/contargo/types/truck/BulgarianLicensePlateHandler.java
+++ b/src/main/java/net/contargo/types/truck/BulgarianLicensePlateHandler.java
@@ -7,7 +7,7 @@ package net.contargo.types.truck;
  *
  * <ul>
  *   <li>A-1234-BB</li>
- *   <li>AAQ-1234-BB</li>
+ *   <li>AA-1234-BB</li>
  * </ul>
  *
  * <p>Further information: <a href="https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Bulgaria#Format">
@@ -70,10 +70,10 @@ class BulgarianLicensePlateHandler implements LicensePlateHandler {
         String normalizedValue = normalize(value);
 
         // A-1234-AA
-        boolean leadingLetter = normalizedValue.matches("[A-Z]\\-[1-9]{4}\\-[A-Z]{2}");
+        boolean leadingLetter = normalizedValue.matches("[A-Z]\\-[0-9]{4}\\-[A-Z]{2}");
 
         // AA-1234-AA
-        boolean leadingLetters = normalizedValue.matches("[A-Z]{2}\\-[1-9]{4}\\-[A-Z]{2}");
+        boolean leadingLetters = normalizedValue.matches("[A-Z]{2}\\-[0-9]{4}\\-[A-Z]{2}");
 
         return leadingLetter || leadingLetters;
     }

--- a/src/main/java/net/contargo/types/truck/BulgarianLicensePlateHandler.java
+++ b/src/main/java/net/contargo/types/truck/BulgarianLicensePlateHandler.java
@@ -1,5 +1,9 @@
 package net.contargo.types.truck;
 
+import java.util.Arrays;
+import java.util.List;
+
+
 /**
  * Can handle Bulgarian {@link LicensePlate}s.
  *
@@ -18,8 +22,24 @@ package net.contargo.types.truck;
  */
 class BulgarianLicensePlateHandler implements LicensePlateHandler {
 
+    private static final String WHITESPACE = " ";
+
     /**
-     * Normalizes the given {@link LicensePlate} value by upper casing it and replacing all whitespaces by hyphens.
+     * The provinces of Bulgaria.
+     *
+     * <p>For further information see the <a
+     * href="https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_Bulgaria#Provincial_codes">list of
+     * provinces</a></p>
+     */
+    private static final List<String> PROVINCES = Arrays.asList("A", "B", "BH", "BP", "BT", "E", "EB", "EH", "K", "KH",
+            "M", "H", "OB", "P", "PA", "PB", "PK", "PP", "C", "CA", "CB", "CH", "CM", "CO", "CC", "CT", "T", "TX", "Y",
+            "X");
+
+    private static final List<String> ACCEPTED_LETTERS = Arrays.asList("A", "B", "M", "H", "P", "C", "T", "Y", "X");
+
+    /**
+     * Normalizes the given {@link LicensePlate} value by upper casing it and replacing all hyphens by whitespaces, and
+     * ensure numbers are seperated from letters.
      *
      * @param  value  to get the normalized value for, never {@code null}
      *
@@ -28,7 +48,9 @@ class BulgarianLicensePlateHandler implements LicensePlateHandler {
     @Override
     public String normalize(String value) {
 
-        return LicensePlateHandler.trim(value).replaceAll("\\s", "-");
+        return LicensePlateHandler.trim(value)
+            .replaceAll("\\-", WHITESPACE)
+            .replaceAll("(?<=\\d)(?=\\p{L})|(?<=\\p{L})(?=\\d)", WHITESPACE);
     }
 
 
@@ -36,7 +58,7 @@ class BulgarianLicensePlateHandler implements LicensePlateHandler {
      * Validates the given {@link LicensePlate} value.
      *
      * <p>A Bulgarian license plate consists of a combination of seven or eight digits and letters. It has three groups
-     * that are separated by a hyphen:</p>
+     * that are separated by a whitespace:</p>
      *
      * <ul>
      *   <li>one leading letter</li>
@@ -57,8 +79,12 @@ class BulgarianLicensePlateHandler implements LicensePlateHandler {
      * <p>There are certain license plates that may deviate from this rule, for example military of police license
      * plates.</p>
      *
-     * <p>Note that these special cases are not covered by this validator! Also this validator considers only the
-     * license plate format in general, but not letter combinations in detail.</p>
+     * <p>Note that these special cases are not covered by this validator!</p>
+     *
+     * <p>The first group depicts the Province where the licens plate is issued, and is validated against the known
+     * list.</p>
+     *
+     * <p>The third group can only consist of certain letters, which are validated.</p>
      *
      * @param  value  to be validated, never {@code null}
      *
@@ -69,12 +95,38 @@ class BulgarianLicensePlateHandler implements LicensePlateHandler {
 
         String normalizedValue = normalize(value);
 
+        if (!isValidFormat(normalizedValue)) {
+            return false;
+        }
+
+        String[] parts = normalizedValue.split(WHITESPACE);
+
+        if (!isLetterGroupValid(parts[2])) {
+            return false;
+        }
+
+        return isProvinceCode(parts[0]);
+    }
+
+
+    private static boolean isValidFormat(String normalizedValue) {
+
         // A-1234-AA
-        boolean leadingLetter = normalizedValue.matches("[A-Z]\\-[0-9]{4}\\-[A-Z]{2}");
+        return normalizedValue.matches("[A-Z]\\s[0-9]{4}\\s[A-Z]{2}")
+            // AA-1234-AA
+            || normalizedValue.matches("[A-Z]{2}\\s[0-9]{4}\\s[A-Z]{2}");
+    }
 
-        // AA-1234-AA
-        boolean leadingLetters = normalizedValue.matches("[A-Z]{2}\\-[0-9]{4}\\-[A-Z]{2}");
 
-        return leadingLetter || leadingLetters;
+    private static boolean isProvinceCode(String countyCode) {
+
+        return PROVINCES.contains(countyCode);
+    }
+
+
+    private boolean isLetterGroupValid(String letterGroup) {
+
+        return ACCEPTED_LETTERS.contains(letterGroup.substring(0, 1))
+            && ACCEPTED_LETTERS.contains(letterGroup.substring(1, 2));
     }
 }

--- a/src/main/java/net/contargo/types/truck/LicensePlateCountry.java
+++ b/src/main/java/net/contargo/types/truck/LicensePlateCountry.java
@@ -19,6 +19,7 @@ public enum LicensePlateCountry implements Country {
     POLAND("PL", "XYZ 12JK", new PolishLicensePlateHandler()),
     CZECH_REPUBLIC("CZ", "2H2 7149", new CzechLicensePlateHandler()),
     ROMANIA("RO", "B 183 CTL", new RomanianLicensePlateHandler()),
+    BULGARIA("BG", "CA 7845 XC", new BulgarianLicensePlateHandler()),
     UNKNOWN_COUNTRY("", "", new UnknownCountryLicensePlateHandler());
 
     private final String countryCode;

--- a/src/test/java/net/contargo/types/truck/BulgarianLicensePlateHandlerTest.java
+++ b/src/test/java/net/contargo/types/truck/BulgarianLicensePlateHandlerTest.java
@@ -83,4 +83,20 @@ public class BulgarianLicensePlateHandlerTest extends AbstractLicensePlateHandle
         assertIsNotValid.accept("G-AB3D-42");
         assertIsNotValid.accept("G-ABCD-4A");
     }
+
+
+    @Test
+    public void ensureLicensePlateWithAllDigitsIsValid() {
+
+        assertIsValid.accept("X-0123-AA");
+        assertIsValid.accept("X-1234-AA");
+        assertIsValid.accept("X-2345-AA");
+        assertIsValid.accept("X-3456-AA");
+        assertIsValid.accept("X-4567-AA");
+        assertIsValid.accept("X-5678-AA");
+        assertIsValid.accept("X-6789-AA");
+        assertIsValid.accept("X-7890-AA");
+        assertIsValid.accept("X-8901-AA");
+        assertIsValid.accept("X-9012-AA");
+    }
 }

--- a/src/test/java/net/contargo/types/truck/BulgarianLicensePlateHandlerTest.java
+++ b/src/test/java/net/contargo/types/truck/BulgarianLicensePlateHandlerTest.java
@@ -21,12 +21,12 @@ public class BulgarianLicensePlateHandlerTest extends AbstractLicensePlateHandle
     @Test
     public void ensureLicensePlateIsNormalizedCorrectly() {
 
-        assertIsNormalizedFromTo.accept("a-1234-mm", "A-1234-MM");
-        assertIsNormalizedFromTo.accept("b-1234-fa", "B-1234-FA");
-        assertIsNormalizedFromTo.accept("a 1234 mm", "A-1234-MM");
-        assertIsNormalizedFromTo.accept("a 1234 mm  ", "A-1234-MM");
-        assertIsNormalizedFromTo.accept("a  1234 mm", "A-1234-MM");
-        assertIsNormalizedFromTo.accept("a--1234--mm", "A-1234-MM");
+        assertIsNormalizedFromTo.accept("a-1234-mm", "A 1234 MM");
+        assertIsNormalizedFromTo.accept("b-1234-fa", "B 1234 FA");
+        assertIsNormalizedFromTo.accept("a 1234 mm", "A 1234 MM");
+        assertIsNormalizedFromTo.accept("a 1234 mm  ", "A 1234 MM");
+        assertIsNormalizedFromTo.accept("a  1234 mm", "A 1234 MM");
+        assertIsNormalizedFromTo.accept("a--1234--mm", "A 1234 MM");
     }
 
 
@@ -35,8 +35,8 @@ public class BulgarianLicensePlateHandlerTest extends AbstractLicensePlateHandle
     @Test
     public void ensureLicensePlateWithThreeGroupsIsValid() {
 
-        assertIsValid.accept("X-1234-AA");
-        assertIsValid.accept("AB-5678-XZ");
+        assertIsValid.accept("X 1234 CH");
+        assertIsValid.accept("CH 5678 TM");
     }
 
 
@@ -63,40 +63,40 @@ public class BulgarianLicensePlateHandlerTest extends AbstractLicensePlateHandle
     @Test
     public void ensureLicensePlateWithOnlyDigitsIsNotValid() {
 
-        assertIsNotValid.accept("1-2345-67");
+        assertIsNotValid.accept("1 2345 67");
     }
 
 
     @Test
     public void ensureLicensePlateWithOnlyLettersIsNotValid() {
 
-        assertIsNotValid.accept("A-BCDE-FG");
-        assertIsNotValid.accept("AB-CDEF-GH");
+        assertIsNotValid.accept("A BCDE FG");
+        assertIsNotValid.accept("AB CDEF GH");
     }
 
 
     @Test
     public void ensureLicensePlateWithMixedUpGroupsIsNotValid() {
 
-        assertIsNotValid.accept("1-A2SV-14");
-        assertIsNotValid.accept("9-123B-9Z");
-        assertIsNotValid.accept("G-AB3D-42");
-        assertIsNotValid.accept("G-ABCD-4A");
+        assertIsNotValid.accept("1 A2SV 14");
+        assertIsNotValid.accept("9 123B 9Z");
+        assertIsNotValid.accept("G AB3D 42");
+        assertIsNotValid.accept("G-ABCD 4A");
     }
 
 
     @Test
     public void ensureLicensePlateWithAllDigitsIsValid() {
 
-        assertIsValid.accept("X-0123-AA");
-        assertIsValid.accept("X-1234-AA");
-        assertIsValid.accept("X-2345-AA");
-        assertIsValid.accept("X-3456-AA");
-        assertIsValid.accept("X-4567-AA");
-        assertIsValid.accept("X-5678-AA");
-        assertIsValid.accept("X-6789-AA");
-        assertIsValid.accept("X-7890-AA");
-        assertIsValid.accept("X-8901-AA");
-        assertIsValid.accept("X-9012-AA");
+        assertIsValid.accept("X 0123 CH");
+        assertIsValid.accept("X 1234 CH");
+        assertIsValid.accept("X 2345 CH");
+        assertIsValid.accept("X 3456 CH");
+        assertIsValid.accept("X 4567 CH");
+        assertIsValid.accept("X 5678 CH");
+        assertIsValid.accept("X 6789 CH");
+        assertIsValid.accept("X 7890 CH");
+        assertIsValid.accept("X 8901 CH");
+        assertIsValid.accept("X 9012 CH");
     }
 }

--- a/src/test/java/net/contargo/types/truck/LicensePlateCountryTest.java
+++ b/src/test/java/net/contargo/types/truck/LicensePlateCountryTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 
 /**
@@ -12,7 +11,7 @@ import java.util.function.Consumer;
  */
 public class LicensePlateCountryTest {
 
-    private BiConsumer<LicensePlateHandler, Class> assertCorrectHandler = (handler, clazz) -> {
+    private final BiConsumer<LicensePlateHandler, Class> assertCorrectHandler = (handler, clazz) -> {
         Assert.assertNotNull("Missing handler", handler);
         Assert.assertEquals("Wrong handler implementation", clazz, handler.getClass());
     };
@@ -36,7 +35,9 @@ public class LicensePlateCountryTest {
         assertCorrectHandler.accept(LicensePlateCountry.CZECH_REPUBLIC.getLicensePlateHandler(),
             CzechLicensePlateHandler.class);
         assertCorrectHandler.accept(LicensePlateCountry.ROMANIA.getLicensePlateHandler(),
-                RomanianLicensePlateHandler.class);
+            RomanianLicensePlateHandler.class);
+        assertCorrectHandler.accept(LicensePlateCountry.BULGARIA.getLicensePlateHandler(),
+            BulgarianLicensePlateHandler.class);
     }
 
 


### PR DESCRIPTION
* on validating digits, a 0 is also valid.
* Fixes Typo in the example license plates.