### PR TITLE
change default max size of licence plate

### DIFF
--- a/src/main/java/net/contargo/types/truck/DefaultLicensePlateHandler.java
+++ b/src/main/java/net/contargo/types/truck/DefaultLicensePlateHandler.java
@@ -36,6 +36,6 @@ class DefaultLicensePlateHandler implements LicensePlateHandler {
     public boolean validate(String value) {
 
         // allowed: any letter or digit, but no special characters except '-' and ' '
-        return normalize(value).matches("[\\p{L}0-9\\- ]*");
+        return normalize(value).matches("[\\p{L}0-9\\- ]{2,15}");
     }
 }

--- a/src/main/java/net/contargo/types/truck/UnknownCountryLicensePlateHandler.java
+++ b/src/main/java/net/contargo/types/truck/UnknownCountryLicensePlateHandler.java
@@ -11,7 +11,7 @@ package net.contargo.types.truck;
  */
 class UnknownCountryLicensePlateHandler implements LicensePlateHandler {
 
-    private static final int MAXIMUM_NUMBER_OF_CHARACTERS = 64;
+    private static final int MAXIMUM_NUMBER_OF_CHARACTERS = 15;
 
     /**
      * Normalizes the given {@link LicensePlate} value by trimming and upper casing value.


### PR DESCRIPTION
set max to 15 because a licence plate can not have amount of 64 characters