### PR TITLE
change PhoneNumber and use it in ContactInformation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,14 @@
 Contargo Types
 ===============
+
+## v0.17.1
+* use PhoneNumber in ContactInformation instead of String for phone- and mobile numbers
+* change PhoneNumber only format number if method is called. Has country code, raw phone number and extension 
+to a phone number. 
+
 ## v0.17.0
 
-* Adds PhoneNumber to formate phone numbers and get information to a spezific phone number, 
+* Adds PhoneNumber to format phone numbers and get information to a specific phone number, 
 like the country code or country calling code.
 * Change the amount of characters for license plates to max. 15 characters.
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>5.1.3.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>net.contargo</groupId>
     <artifactId>contargo-types</artifactId>
-    <version>0.16.1</version>
+    <version>0.17.1</version>
     <packaging>jar</packaging>
 
     <name>Contargo Types</name>
@@ -74,11 +74,6 @@
             <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>5.1.3.RELEASE</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/net/contargo/types/contactinfo/ContactInformation.java
+++ b/src/main/java/net/contargo/types/contactinfo/ContactInformation.java
@@ -17,9 +17,15 @@ public class ContactInformation {
 
     public ContactInformation(String userUUID, String mobile, String phone, String email) {
 
+        this(userUUID, new PhoneNumber(mobile), new PhoneNumber(phone), email);
+    }
+
+
+    public ContactInformation(String userUUID, PhoneNumber mobile, PhoneNumber phone, String email) {
+
         this.userUUID = userUUID;
-        this.mobile = new PhoneNumber(mobile);
-        this.phone = new PhoneNumber(phone);
+        this.mobile = mobile;
+        this.phone = phone;
         this.email = email;
     }
 

--- a/src/main/java/net/contargo/types/contactinfo/ContactInformation.java
+++ b/src/main/java/net/contargo/types/contactinfo/ContactInformation.java
@@ -17,15 +17,9 @@ public class ContactInformation {
 
     public ContactInformation(String userUUID, String mobile, String phone, String email) {
 
-        this(userUUID, new PhoneNumber(mobile), new PhoneNumber(phone), email);
-    }
-
-
-    public ContactInformation(String userUUID, PhoneNumber mobile, PhoneNumber phone, String email) {
-
         this.userUUID = userUUID;
-        this.mobile = mobile;
-        this.phone = phone;
+        this.mobile = new PhoneNumber(mobile);
+        this.phone = new PhoneNumber(phone);
         this.email = email;
     }
 

--- a/src/main/java/net/contargo/types/contactinfo/ContactInformation.java
+++ b/src/main/java/net/contargo/types/contactinfo/ContactInformation.java
@@ -1,5 +1,8 @@
 package net.contargo.types.contactinfo;
 
+import net.contargo.types.telephony.PhoneNumber;
+
+
 /**
  * Contact options for a user in the COLA environment.
  *
@@ -8,15 +11,15 @@ package net.contargo.types.contactinfo;
 public class ContactInformation {
 
     private final String userUUID;
-    private final String mobile;
-    private final String phone;
+    private final PhoneNumber mobile;
+    private final PhoneNumber phone;
     private final String email;
 
     public ContactInformation(String userUUID, String mobile, String phone, String email) {
 
         this.userUUID = userUUID;
-        this.mobile = mobile;
-        this.phone = phone;
+        this.mobile = new PhoneNumber(mobile);
+        this.phone = new PhoneNumber(phone);
         this.email = email;
     }
 
@@ -26,16 +29,17 @@ public class ContactInformation {
     }
 
 
-    public String getMobile() {
+    public PhoneNumber getMobile() {
 
         return mobile;
     }
 
 
-    public String getPhone() {
+    public PhoneNumber getPhone() {
 
         return phone;
     }
+
 
     public String getEmail() {
 

--- a/src/main/java/net/contargo/types/contactinfo/normalization/PhoneNumberNormalizer.java
+++ b/src/main/java/net/contargo/types/contactinfo/normalization/PhoneNumberNormalizer.java
@@ -3,7 +3,7 @@ package net.contargo.types.contactinfo.normalization;
 import net.contargo.types.Loggable;
 import net.contargo.types.telephony.PhoneNumber;
 
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Optional;
 
@@ -12,7 +12,7 @@ public class PhoneNumberNormalizer implements Loggable {
 
     public Optional<String> normalizeNumber(String phoneNumber) {
 
-        if (StringUtils.hasText(phoneNumber)) {
+        if (StringUtils.isBlank(phoneNumber)) {
             return Optional.empty();
         }
 

--- a/src/main/java/net/contargo/types/contactinfo/normalization/PhoneNumberNormalizer.java
+++ b/src/main/java/net/contargo/types/contactinfo/normalization/PhoneNumberNormalizer.java
@@ -1,8 +1,9 @@
 package net.contargo.types.contactinfo.normalization;
 
 import net.contargo.types.Loggable;
-import net.contargo.types.telephony.formatting.PhoneNumberFormatter;
-import net.contargo.types.telephony.formatting.PhoneNumberFormattingException;
+import net.contargo.types.telephony.PhoneNumber;
+
+import org.springframework.util.StringUtils;
 
 import java.util.Optional;
 
@@ -11,16 +12,10 @@ public class PhoneNumberNormalizer implements Loggable {
 
     public Optional<String> normalizeNumber(String phoneNumber) {
 
-        if (phoneNumber == null) {
+        if (StringUtils.hasText(phoneNumber)) {
             return Optional.empty();
         }
 
-        try {
-            return Optional.of(new PhoneNumberFormatter().parseAndFormatToE164Format(phoneNumber));
-        } catch (PhoneNumberFormattingException e) {
-            logger().warn("Failed to parse and format number {}: {}", phoneNumber, e.getMessage());
-
-            return Optional.empty();
-        }
+        return new PhoneNumber(phoneNumber).getInternationalFormatOfPhoneNumber();
     }
 }

--- a/src/main/java/net/contargo/types/contactinfo/validation/ExternalUserCompletenessValidator.java
+++ b/src/main/java/net/contargo/types/contactinfo/validation/ExternalUserCompletenessValidator.java
@@ -9,8 +9,7 @@ import java.util.List;
 
 
 /**
- * Checks the completeness of a contact information object according to the
- * rules for external COLA users:
+ * Checks the completeness of a contact information object according to the rules for external COLA users:
  *
  * <ul>
  *   <li>Must be contactable via text message; This is either an e-mail address or a mobile number for SMS
@@ -26,8 +25,8 @@ public class ExternalUserCompletenessValidator implements CompletenessValidator 
         List<ValidationResult> messages = new ArrayList<>();
 
         final boolean missingEmail = StringUtils.isEmpty(contactInformation.getEmail());
-        final boolean missingMobile = StringUtils.isEmpty(contactInformation.getMobile());
-        final boolean missingPhone = StringUtils.isEmpty(contactInformation.getPhone());
+        final boolean missingMobile = !contactInformation.getMobile().isPhoneNumber();
+        final boolean missingPhone = !contactInformation.getPhone().isPhoneNumber();
 
         if (missingEmail && missingMobile) {
             messages.add(ValidationResult.MISSING_EMAIL);

--- a/src/main/java/net/contargo/types/telephony/PhoneNumber.java
+++ b/src/main/java/net/contargo/types/telephony/PhoneNumber.java
@@ -8,6 +8,7 @@ import net.contargo.types.telephony.formatting.PhoneNumberFormattingException;
 
 import org.apache.commons.lang.StringUtils;
 
+import java.util.Objects;
 import java.util.Optional;
 
 
@@ -44,6 +45,12 @@ public final class PhoneNumber implements Loggable {
         this(country, rawPhoneNumber, null);
     }
 
+    public String getRawPhoneNumber() {
+
+        return rawPhoneNumber;
+    }
+
+
     public String getPhoneExtension() {
 
         return phoneExtension;
@@ -58,7 +65,11 @@ public final class PhoneNumber implements Loggable {
 
     public Country getCountry() throws PhoneNumberFormattingException {
 
-        return new Country(phoneNumberFormatter.getRegionCode(rawPhoneNumber));
+        if (Objects.isNull(country)) {
+            country = new Country(phoneNumberFormatter.getRegionCode(rawPhoneNumber));
+        }
+
+        return country;
     }
 
 
@@ -78,13 +89,15 @@ public final class PhoneNumber implements Loggable {
 
         logger().info("formatting phone number: {} into international phone number.", getPhoneNumber());
 
-        if (StringUtils.isBlank(rawPhoneNumber)) {
+        if (StringUtils.isBlank(rawPhoneNumber) || containsOnlyZeros(rawPhoneNumber)) {
             logger().warn("Not able to parse phone number of {}", rawPhoneNumber);
 
             return Optional.empty();
         }
 
         try {
+            country = new Country(phoneNumberFormatter.getRegionCode(rawPhoneNumber));
+
             return Optional.of(phoneNumberFormatter.parseAndFormatToDIN5008(getPhoneNumber()));
         } catch (PhoneNumberFormattingException e) {
             logger().warn("Failed to parse and format number {}: {}", rawPhoneNumber, e.getMessage());
@@ -107,6 +120,12 @@ public final class PhoneNumber implements Loggable {
     public boolean isPhoneNumber() {
 
         return getInternationalFormatOfPhoneNumber().isPresent();
+    }
+
+
+    private boolean containsOnlyZeros(String number) {
+
+        return number.matches("0+$");
     }
 
 

--- a/src/main/java/net/contargo/types/telephony/PhoneNumber.java
+++ b/src/main/java/net/contargo/types/telephony/PhoneNumber.java
@@ -6,7 +6,7 @@ import net.contargo.types.Loggable;
 import net.contargo.types.telephony.formatting.PhoneNumberFormatter;
 import net.contargo.types.telephony.formatting.PhoneNumberFormattingException;
 
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Optional;
 
@@ -78,7 +78,7 @@ public final class PhoneNumber implements Loggable {
 
         logger().info("formatting phone number: {} into international phone number.", getPhoneNumber());
 
-        if (!StringUtils.hasText(rawPhoneNumber)) {
+        if (StringUtils.isBlank(rawPhoneNumber)) {
             logger().warn("Not able to parse phone number of {}", rawPhoneNumber);
 
             return Optional.empty();
@@ -96,7 +96,7 @@ public final class PhoneNumber implements Loggable {
 
     private String getPhoneNumber() {
 
-        if (StringUtils.hasText(phoneExtension)) {
+        if (StringUtils.isNotBlank(phoneExtension)) {
             return String.format("%s%s", rawPhoneNumber, phoneExtension);
         }
 

--- a/src/main/java/net/contargo/types/telephony/formatting/PhoneNumberFormatter.java
+++ b/src/main/java/net/contargo/types/telephony/formatting/PhoneNumberFormatter.java
@@ -102,7 +102,7 @@ public class PhoneNumberFormatter {
         final String formattedBaseNumber = parseAndFormatToDIN5008(basePhoneNumber);
         final String sanitizedExtension = extension.replaceAll("\\s+", "").replaceAll("\\D+", "");
 
-        return String.format("%s-%s", formattedBaseNumber, sanitizedExtension);
+        return String.format("%s %s", formattedBaseNumber, sanitizedExtension);
     }
 
 
@@ -246,7 +246,9 @@ public class PhoneNumberFormatter {
      */
     private String trimPhoneNumber(String phoneNumber) {
 
-        return phoneNumber.replaceAll("\\s+", "").replaceAll("\n", "");
+        String phoneNumberWithoutNewLine = phoneNumber.replaceAll("\\s+", "").replaceAll("\n", "");
+
+        return phoneNumberWithoutNewLine.replaceAll("/", "").replaceAll("-", "");
     }
 
     private class AreaCodeAndConnectionNumber {

--- a/src/main/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidator.java
+++ b/src/main/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidator.java
@@ -1,9 +1,8 @@
 package net.contargo.types.telephony.validation;
 
-import com.google.i18n.phonenumbers.NumberParseException;
-import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import net.contargo.types.telephony.PhoneNumber;
 
-import java.util.Objects;
+import org.apache.commons.lang.StringUtils;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -17,8 +16,6 @@ import javax.validation.ConstraintValidatorContext;
  */
 public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhoneNumber, String> {
 
-    private final PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
-
     @Override
     public void initialize(ValidPhoneNumber a) {
 
@@ -27,21 +24,21 @@ public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhone
 
 
     @Override
-    public boolean isValid(String phoneNumber, ConstraintValidatorContext cvc) {
+    public boolean isValid(String value, ConstraintValidatorContext cvc) {
+
+        PhoneNumber phoneNumber = new PhoneNumber(value);
 
         // We must assume non-null, non-empty is validated elsewhere
-        if (Objects.isNull(phoneNumber) || phoneNumber.trim().isEmpty()) {
+        if (StringUtils.isBlank(value) || phoneNumber.getRawPhoneNumber().trim().isEmpty()) {
             return true;
         }
 
-        String phoneNumberWithoutWhitespace = phoneNumber.replaceAll("\\s+", "");
+        return phoneNumber.isPhoneNumber() && !isPhoneNumberOnlyZeros(phoneNumber);
+    }
 
-        try {
-            phoneNumberUtil.parse(phoneNumberWithoutWhitespace, "DE");
 
-            return true;
-        } catch (NumberParseException e1) {
-            return false;
-        }
+    private boolean isPhoneNumberOnlyZeros(PhoneNumber phoneNumber) {
+
+        return phoneNumber.getRawPhoneNumber().matches("0+$");
     }
 }

--- a/src/test/java/net/contargo/types/contactinfo/validation/ExternalUserContactInfoCompletenessValidatorTest.java
+++ b/src/test/java/net/contargo/types/contactinfo/validation/ExternalUserContactInfoCompletenessValidatorTest.java
@@ -18,8 +18,8 @@ public class ExternalUserContactInfoCompletenessValidatorTest {
 
         ExternalUserCompletenessValidator externalUserCompletenessValidator = new ExternalUserCompletenessValidator();
 
-        ContactInformation contactInfoWithAllData = new ContactInformation(UUID.randomUUID().toString(), "mobile",
-                "phone", "email");
+        ContactInformation contactInfoWithAllData = new ContactInformation(UUID.randomUUID().toString(),
+                "0156272364623", "0049574753847", "email");
         List<ValidationResult> validationResults = externalUserCompletenessValidator.checkCompleteness(
                 contactInfoWithAllData);
         assertTrue(validationResults.isEmpty());
@@ -32,7 +32,7 @@ public class ExternalUserContactInfoCompletenessValidatorTest {
         ExternalUserCompletenessValidator externalUserCompletenessValidator = new ExternalUserCompletenessValidator();
 
         ContactInformation contactInfoWithoutEmailAndMobile = new ContactInformation(UUID.randomUUID().toString(), "",
-                "phone", "");
+                "00234234234", "");
         List<ValidationResult> validationResults = externalUserCompletenessValidator.checkCompleteness(
                 contactInfoWithoutEmailAndMobile);
 

--- a/src/test/java/net/contargo/types/contactinfo/validation/ReactiveUniquenessValidatorTest.java
+++ b/src/test/java/net/contargo/types/contactinfo/validation/ReactiveUniquenessValidatorTest.java
@@ -21,19 +21,16 @@ public class ReactiveUniquenessValidatorTest {
 
         List<ContactInformation> allProfiles = new ArrayList<>();
 
-        ContactInformation contactInformation1 = new ContactInformation("uuid1", "1234", "4567", "foo1@bar"
-        );
+        ContactInformation contactInformation1 = new ContactInformation("uuid1", "01234", "04567", "foo1@bar");
         allProfiles.add(contactInformation1);
 
-        ContactInformation contactInformation2 = new ContactInformation("uuid2", "1233", "4567", "foo@bar");
+        ContactInformation contactInformation2 = new ContactInformation("uuid2", "01233", "04567", "foo@bar");
         allProfiles.add(contactInformation2);
 
-        ContactInformation contactInformation3 = new ContactInformation("uuid3", "171789987", "4567", "foo@baz"
-        );
+        ContactInformation contactInformation3 = new ContactInformation("uuid3", "0171789987", "04567", "foo@baz");
         allProfiles.add(contactInformation3);
 
-        ContactInformation contactInformation4 = new ContactInformation("uuid4", "171789987", "4567", "foo@bazl"
-        );
+        ContactInformation contactInformation4 = new ContactInformation("uuid4", "0171789987", "04567", "foo@bazl");
         allProfiles.add(contactInformation4);
 
         colaProfileConsumer.consume(allProfiles);
@@ -42,43 +39,43 @@ public class ReactiveUniquenessValidatorTest {
 
     private ContactInformation contactInformationWithAllData() {
 
-        return new ContactInformation("uuid1", "171789987", "721321451", "foo@bar");
+        return new ContactInformation("uuid1", "0171789987", "0721321451", "foo@bar");
     }
 
 
     private ContactInformation contactInformationWithAllDataAndDuplicateMailOfOtherUser() {
 
-        return new ContactInformation("uuid1", "", "721321451", "foo@baz");
+        return new ContactInformation("uuid1", "", "0721321451", "foo@baz");
     }
 
 
     private ContactInformation contactInformationWithDuplicateMailAfterNormalization() {
 
-        return new ContactInformation("uuid1-1", "", "721321451", "foo1@BAR");
+        return new ContactInformation("uuid1-1", "", "0721321451", "foo1@BAR");
     }
 
 
     private ContactInformation contactInformationWithAllDataAndDistinctMail() {
 
-        return new ContactInformation("uuid3", "", "721321451", "foo@baz");
+        return new ContactInformation("uuid3", "", "0721321451", "foo@baz");
     }
 
 
     private ContactInformation contactInformationWithAllDataAndDistinctMobile() {
 
-        return new ContactInformation("uuid4", "171789988", "721321451", "foo@barz");
+        return new ContactInformation("uuid4", "0171789988", "0721321451", "foo@barz");
     }
 
 
     private ContactInformation contactInformationWithDuplicateMobileAfterNormalization() {
 
-        return new ContactInformation("uuid5", "+49171789987", "721321451", null);
+        return new ContactInformation("uuid5", "+49171789987", "0721321451", null);
     }
 
 
     private ContactInformation contactInformationWithDuplicateMobile() {
 
-        return new ContactInformation("uuid5", "171789987", "721321451", null);
+        return new ContactInformation("uuid5", "0171789987", "0721321451", null);
     }
 
 
@@ -90,7 +87,7 @@ public class ReactiveUniquenessValidatorTest {
 
     private ContactInformation contactInformationWithoutEmailAndMobile() {
 
-        return new ContactInformation("uuid1", null, "1728092174", null);
+        return new ContactInformation("uuid1", null, "01728092174", null);
     }
 
 
@@ -111,6 +108,7 @@ public class ReactiveUniquenessValidatorTest {
         assertEquals(ValidationResult.NON_UNIQUE_MOBILE, validationResults.get(0));
     }
 
+
     @Test
     public void ensureThatConsumingNullProfileDoesNotThrow() {
 
@@ -127,8 +125,8 @@ public class ReactiveUniquenessValidatorTest {
         ReactiveUniquenessValidator reactiveUniquenessValidator = new ReactiveUniquenessValidator(
                 new PhoneNumberNormalizer(), new EmailAddressNormalizer());
 
-        ContactInformation contactInfoWithNullValue1 = new ContactInformation("uuid1", "1234", null, null);
-        ContactInformation contactInfoWithNullValue2 = new ContactInformation("uuid2", "1234", null, null);
+        ContactInformation contactInfoWithNullValue1 = new ContactInformation("uuid1", "001234", null, null);
+        ContactInformation contactInfoWithNullValue2 = new ContactInformation("uuid2", "001234", null, null);
 
         reactiveUniquenessValidator.consume(contactInfoWithNullValue1);
 
@@ -150,30 +148,34 @@ public class ReactiveUniquenessValidatorTest {
         assertDetectionOfDuplicateMobile(reactiveUniquenessValidator, contactInformationWithDuplicateMobile());
     }
 
+
     @Test
     public void ensureThatDuplicateMobileIsDetectedAndNotDetectedAfterConflictingUserRemovedMobile() {
 
-        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid2", "", "4567",
+        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid2", "", "004567",
                 "foo-uuid2@bar");
-        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "1233", "4567",
+        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "001233", "004567",
                 "foo-uuid8@bar");
 
         ensureDuplicateMobileIsDetectedAndNotDetected(contactInfoToBeChanged, contactInfoToBeValidated);
     }
+
 
     @Test
     public void ensureThatDuplicateMobileIsDetectedAndNotDetectedAfterConflictingUserChangedMobile() {
 
-        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid2", "12345", "4567",
+        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid2", "012345", "04567",
                 "foo-uuid2@bar");
-        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "1233", "4567",
+        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "012335", "04567",
                 "foo-uuid8@bar");
-
 
         ensureDuplicateMobileIsDetectedAndNotDetected(contactInfoToBeChanged, contactInfoToBeValidated);
     }
 
-    private void ensureDuplicateMobileIsDetectedAndNotDetected(ContactInformation contactInfoToBeChanged, ContactInformation contactInfoToBeValidated) {
+
+    private void ensureDuplicateMobileIsDetectedAndNotDetected(ContactInformation contactInfoToBeChanged,
+        ContactInformation contactInfoToBeValidated) {
+
         ReactiveUniquenessValidator reactiveUniquenessValidator = new ReactiveUniquenessValidator(
                 new PhoneNumberNormalizer(), new EmailAddressNormalizer());
         consumeColaProfiles(reactiveUniquenessValidator);
@@ -184,29 +186,31 @@ public class ReactiveUniquenessValidatorTest {
         assertThatNoValidationErrorIsReported(reactiveUniquenessValidator, contactInfoToBeValidated);
     }
 
+
     @Test
     public void ensureThatDuplicateMailIsDetectedAndNotDetectedAfterConflictingUserRemovedMail() {
 
-        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid4", "12345", "4567", ""
-        );
-        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "", "4567", "foo@bazl"
-        );
+        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid4", "012345", "04567", "");
+        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "", "04567", "foo@bazl");
 
         ensureDuplicateMailIsDetectedAndNotDected(contactInfoToBeChanged, contactInfoToBeValidated);
     }
+
 
     @Test
     public void ensureThatDuplicateMailIsDetectedAndNotDetectedAfterConflictingUserChangedMail() {
 
-        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid4", "12345", "4567", "foo@bazk"
-        );
-        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "", "4567", "foo@bazl"
-        );
+        final ContactInformation contactInfoToBeChanged = new ContactInformation("uuid4", "012345", "04567",
+                "foo@bazk");
+        final ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "", "04567", "foo@bazl");
 
         ensureDuplicateMailIsDetectedAndNotDected(contactInfoToBeChanged, contactInfoToBeValidated);
     }
 
-    private void ensureDuplicateMailIsDetectedAndNotDected(ContactInformation contactInfoToBeChanged, ContactInformation contactInfoToBeValidated) {
+
+    private void ensureDuplicateMailIsDetectedAndNotDected(ContactInformation contactInfoToBeChanged,
+        ContactInformation contactInfoToBeValidated) {
+
         ReactiveUniquenessValidator reactiveUniquenessValidator = new ReactiveUniquenessValidator(
                 new PhoneNumberNormalizer(), new EmailAddressNormalizer());
 
@@ -228,10 +232,8 @@ public class ReactiveUniquenessValidatorTest {
 
         assertDetectionOfDuplicateMobile(reactiveUniquenessValidator, contactInformationWithDuplicateMobile());
 
-        ContactInformation contactInfoToBeRemoved = new ContactInformation("uuid2", "1233", "4567", "foo@bar"
-        );
-        ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "1233", "4567", "foo@bar"
-        );
+        ContactInformation contactInfoToBeRemoved = new ContactInformation("uuid2", "01233", "04567", "foo@bar");
+        ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "01233", "04567", "foo@bar");
         reactiveUniquenessValidator.remove(contactInfoToBeRemoved);
         assertThatNoValidationErrorIsReported(reactiveUniquenessValidator, contactInfoToBeValidated);
     }
@@ -247,10 +249,8 @@ public class ReactiveUniquenessValidatorTest {
         assertDetectionOfDuplicateMail(reactiveUniquenessValidator,
             contactInformationWithDuplicateMailAfterNormalization());
 
-        ContactInformation contactInfoToBeRemoved = new ContactInformation("uuid3", "1233", "4567", "foo@baz"
-        );
-        ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "1233123", "4567", "foo@baz"
-        );
+        ContactInformation contactInfoToBeRemoved = new ContactInformation("uuid3", "01233", "04567", "foo@baz");
+        ContactInformation contactInfoToBeValidated = new ContactInformation("uuid8", "01233123", "04567", "foo@baz");
         reactiveUniquenessValidator.remove(contactInfoToBeRemoved);
         assertThatNoValidationErrorIsReported(reactiveUniquenessValidator, contactInfoToBeValidated);
     }

--- a/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
+++ b/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
@@ -32,11 +32,10 @@ public class PhoneNumberTest {
 
 
     @Test
-    public void ensureInternationalFormattingPhoneNumberFromInvalidInputThrows()
-        throws PhoneNumberFormattingException {
+    public void ensureInternationalFormattingPhoneNumberFromInvalidInput() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("i321%6&_-?`");
-        assertFalse(phoneNumber.getInternationalFormatOfPhoneNumber().isPresent());
+        assertFalse(phoneNumber.isPhoneNumber());
     }
 
 
@@ -65,6 +64,7 @@ public class PhoneNumberTest {
 
         assertEquals("+1", phoneNumber.getCountry().getCountryCallingCode());
         assertEquals("BS", phoneNumber.getCountry().getCountryCode());
+        assertEquals("+1 242 7836 4736", phoneNumber.getInternationalFormatOfPhoneNumber().get());
     }
 
 
@@ -93,5 +93,29 @@ public class PhoneNumberTest {
         phoneNumber.setPhoneExtension("56");
 
         assertEquals("+49 234 2323 5234 2356", phoneNumber.getInternationalFormatOfPhoneNumber().get());
+    }
+
+
+    @Test
+    public void ensureGettingCorrectFormattedGermanNumber() {
+
+        final PhoneNumber phoneNumber = new PhoneNumber("072183478374");
+
+        assertEquals("+49 721 8347 8374", phoneNumber.getInternationalFormatOfPhoneNumber().get());
+    }
+
+
+    @Test
+    public void ensureGetFormattingPhoneNumberFromMixedPhoneNumber() {
+
+        /*
+         * currently phoneNumber lib converts mixed numbers to correct phoneNumbers
+         * falsehoods of phone numbers says that 'numbers' can contain letters
+         * if there are too many problems think about excluding letters in a custom contargo phone number validator
+         */
+        final PhoneNumber phoneNumber = new PhoneNumber("a234svljshdf034");
+
+        assertEquals("+49 234 7585 7433 034", phoneNumber.getInternationalFormatOfPhoneNumber().get());
+        assertTrue(phoneNumber.isPhoneNumber());
     }
 }

--- a/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
+++ b/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
@@ -2,14 +2,15 @@ package net.contargo.types.telephony;
 
 import net.contargo.types.telephony.formatting.PhoneNumberFormattingException;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.junit.runner.RunWith;
 
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
 
 
 /**
@@ -19,40 +20,41 @@ import static org.junit.Assert.assertEquals;
 public class PhoneNumberTest {
 
     @Test
-    public void ensureInternationalFormattingPhoneNumberFromValid() throws PhoneNumberFormattingException {
+    public void ensureInternationalFormattingPhoneNumberFromValid() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("00492342323523423");
 
-        String formattedPhoneNumber = phoneNumber.getInternationalFormattedPhoneNumber();
+        Optional<String> formattedPhoneNumber = phoneNumber.getInternationalFormatOfPhoneNumber();
 
-        assertEquals("+49 234 2323 5234 23", formattedPhoneNumber);
+        assertTrue(formattedPhoneNumber.isPresent());
+        assertEquals("+49 234 2323 5234 23", formattedPhoneNumber.get());
     }
 
 
-    @Test(expected = PhoneNumberFormattingException.class)
+    @Test
     public void ensureInternationalFormattingPhoneNumberFromInvalidInputThrows()
         throws PhoneNumberFormattingException {
 
         final PhoneNumber phoneNumber = new PhoneNumber("i321%6&_-?`");
-        phoneNumber.getInternationalFormattedPhoneNumber();
+        assertFalse(phoneNumber.getInternationalFormatOfPhoneNumber().isPresent());
     }
 
 
     @Test
-    public void ensureFormatsRussianMobile() throws PhoneNumberFormattingException {
+    public void ensureFormatsRussianMobile() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("+7 (922) 555-1234");
 
-        Assert.assertEquals("+7 922 5551 234", phoneNumber.getInternationalFormattedPhoneNumber());
+        assertEquals("+7 922 5551 234", phoneNumber.getInternationalFormatOfPhoneNumber().get());
     }
 
 
     @Test
-    public void ensureFormatsLongGermanMobileNumber() throws PhoneNumberFormattingException {
+    public void ensureFormatsLongGermanMobileNumber() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("0171123456789123");
 
-        Assert.assertEquals("+49 171 1234 5678 9123", phoneNumber.getInternationalFormattedPhoneNumber());
+        assertEquals("+49 171 1234 5678 9123", phoneNumber.getInternationalFormatOfPhoneNumber().get());
     }
 
 
@@ -61,8 +63,8 @@ public class PhoneNumberTest {
 
         final PhoneNumber phoneNumber = new PhoneNumber("00124278364736");
 
-        Assert.assertEquals("+1", phoneNumber.getCountry().getCountryCallingCode());
-        Assert.assertEquals("BS", phoneNumber.getCountry().getCountryCode());
+        assertEquals("+1", phoneNumber.getCountry().getCountryCallingCode());
+        assertEquals("BS", phoneNumber.getCountry().getCountryCode());
     }
 
 
@@ -71,24 +73,25 @@ public class PhoneNumberTest {
 
         final PhoneNumber phoneNumber = new PhoneNumber("00124278364736");
 
-        Assert.assertEquals("24278364736", phoneNumber.getNationalSignificantNumber());
+        assertEquals("24278364736", phoneNumber.getNationalSignificantNumber());
     }
 
+
     @Test
-    public void ensureGermanNumberToInternationalPhoneNumber() throws PhoneNumberFormattingException {
+    public void ensureGermanNumberToInternationalPhoneNumber() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("02342323523423");
 
-        Assert.assertEquals("+49 234 2323 5234 23", phoneNumber.getInternationalFormattedPhoneNumber());
+        assertEquals("+49 234 2323 5234 23", phoneNumber.getInternationalFormatOfPhoneNumber().get());
     }
 
 
     @Test
-    public void ensureGettingCorrectNumberWithPhoneExtension() throws PhoneNumberFormattingException {
+    public void ensureGettingCorrectNumberWithPhoneExtension() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("02342323523423");
         phoneNumber.setPhoneExtension("56");
 
-        Assert.assertEquals("+49 234 2323 5234 2356", phoneNumber.getInternationalFormattedPhoneNumber());
+        assertEquals("+49 234 2323 5234 2356", phoneNumber.getInternationalFormatOfPhoneNumber().get());
     }
 }

--- a/src/test/java/net/contargo/types/telephony/formatting/PhoneNumberFormatterTest.java
+++ b/src/test/java/net/contargo/types/telephony/formatting/PhoneNumberFormatterTest.java
@@ -81,9 +81,9 @@ public class PhoneNumberFormatterTest {
     @Test
     public void ensureThatFormattingWithExtensionWorks() throws PhoneNumberFormattingException {
 
-        Assert.assertEquals("+49 6222 1234 5678-89",
+        Assert.assertEquals("+49 6222 1234 5678 89",
             phoneNumberFormatter.parseAndFormatToDIN5008("0622212345678", "8-9"));
-        Assert.assertEquals("+49 6222 1234 5678-89",
+        Assert.assertEquals("+49 6222 1234 5678 89",
             phoneNumberFormatter.parseAndFormatToDIN5008("0622212345678", "89"));
     }
 }

--- a/src/test/java/net/contargo/types/telephony/formatting/PhoneNumberFormatterTest.java
+++ b/src/test/java/net/contargo/types/telephony/formatting/PhoneNumberFormatterTest.java
@@ -86,4 +86,13 @@ public class PhoneNumberFormatterTest {
         Assert.assertEquals("+49 6222 1234 5678 89",
             phoneNumberFormatter.parseAndFormatToDIN5008("0622212345678", "89"));
     }
+
+
+    @Test
+    public void ensureAreaCodeIsCorrectly() throws PhoneNumberFormattingException {
+
+        Assert.assertEquals("+252 4243 27", phoneNumberFormatter.parseAndFormatToDIN5008("+252424327"));
+        Assert.assertEquals("424327", phoneNumberFormatter.getNationalSignificantNumber("+252424327"));
+        Assert.assertEquals("SO", phoneNumberFormatter.getRegionCode("+252424327")); // SO = Somalia
+    }
 }


### PR DESCRIPTION
only format phonenumber when getInternationalFormatOfPhoneNumber() is called.
do only format if the rawPhoneNumber of the PhoneNumber is not null and no
PhoneNumberFormattingException is thrown.
PhoneNumber is used in ContactInformation instead of Strings of a phone number.