### PR TITLE
update PhoneNumberFormatter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Contargo Types
 ===============
 
+## v0.17.3
+
+* fix PhoneNumberFormatter, the numbers was formatted by the google library and then splitted into country code, areaCode 
+and connectionNumber. If the Number does have connectionNumbers with mor than on empty space splitted only the first part
+was used. 
+
 ## v0.17.2
 
 * fix broken tests from PhoneNumbers. 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>net.contargo</groupId>
     <artifactId>contargo-types</artifactId>
-    <version>0.17.2</version>
+    <version>0.17.3</version>
     <packaging>jar</packaging>
 
     <name>Contargo Types</name>

--- a/src/main/java/net/contargo/types/contactinfo/validation/ExternalUserCompletenessValidator.java
+++ b/src/main/java/net/contargo/types/contactinfo/validation/ExternalUserCompletenessValidator.java
@@ -25,8 +25,8 @@ public class ExternalUserCompletenessValidator implements CompletenessValidator 
         List<ValidationResult> messages = new ArrayList<>();
 
         final boolean missingEmail = StringUtils.isEmpty(contactInformation.getEmail());
-        final boolean missingMobile = !contactInformation.getMobile().isPhoneNumber();
-        final boolean missingPhone = !contactInformation.getPhone().isPhoneNumber();
+        final boolean missingMobile = !contactInformation.getMobile().canBeFormatted();
+        final boolean missingPhone = !contactInformation.getPhone().canBeFormatted();
 
         if (missingEmail && missingMobile) {
             messages.add(ValidationResult.MISSING_EMAIL);

--- a/src/main/java/net/contargo/types/telephony/PhoneNumber.java
+++ b/src/main/java/net/contargo/types/telephony/PhoneNumber.java
@@ -26,6 +26,12 @@ public final class PhoneNumber implements Loggable {
     private final String rawPhoneNumber;
     private String phoneExtension;
 
+    public PhoneNumber() {
+
+        this.rawPhoneNumber = "";
+    }
+
+
     public PhoneNumber(String rawPhoneNumber) {
 
         this.rawPhoneNumber = rawPhoneNumber;

--- a/src/main/java/net/contargo/types/telephony/PhoneNumber.java
+++ b/src/main/java/net/contargo/types/telephony/PhoneNumber.java
@@ -25,6 +25,7 @@ public final class PhoneNumber implements Loggable {
     private Country country;
     private final String rawPhoneNumber;
     private String phoneExtension;
+    private boolean isMobile = false;
 
     public PhoneNumber() {
 
@@ -95,7 +96,7 @@ public final class PhoneNumber implements Loggable {
 
         logger().info("formatting phone number: {} into international phone number.", getPhoneNumber());
 
-        if (StringUtils.isBlank(rawPhoneNumber) || containsOnlyZeros(rawPhoneNumber)) {
+        if (StringUtils.isBlank(rawPhoneNumber) || containsOnlyZeros()) {
             logger().warn("Not able to parse phone number of {}", rawPhoneNumber);
 
             return Optional.empty();
@@ -123,15 +124,27 @@ public final class PhoneNumber implements Loggable {
     }
 
 
-    public boolean isPhoneNumber() {
+    public boolean canBeFormatted() {
 
         return getInternationalFormatOfPhoneNumber().isPresent();
     }
 
 
-    private boolean containsOnlyZeros(String number) {
+    public boolean containsOnlyZeros() {
 
-        return number.matches("0+$");
+        return rawPhoneNumber.matches("0+$");
+    }
+
+
+    public boolean isMobile() {
+
+        return isMobile;
+    }
+
+
+    public void setMobile(boolean mobile) {
+
+        isMobile = mobile;
     }
 
 

--- a/src/main/java/net/contargo/types/telephony/formatting/PhoneNumberFormatter.java
+++ b/src/main/java/net/contargo/types/telephony/formatting/PhoneNumberFormatter.java
@@ -2,9 +2,14 @@ package net.contargo.types.telephony.formatting;
 
 import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType;
 import com.google.i18n.phonenumbers.Phonenumber;
 
+import net.contargo.types.Loggable;
+
 import org.apache.commons.lang.StringUtils;
+
+import java.util.Arrays;
 
 
 /**
@@ -13,7 +18,7 @@ import org.apache.commons.lang.StringUtils;
  * @author  Robin Jayasinghe - jayasinghe@synyx.de
  * @author  Julia Dasch - dasch@synyx.de
  */
-public class PhoneNumberFormatter {
+public class PhoneNumberFormatter implements Loggable {
 
     private static PhoneNumberFormatter instance = null;
 
@@ -67,22 +72,29 @@ public class PhoneNumberFormatter {
     public String parseAndFormatToDIN5008(final String phoneNumber) throws PhoneNumberFormattingException {
 
         // strip all whitespace and line breaks from input
-        final String phoneNumberWithoutWhitespace = trimPhoneNumber(phoneNumber);
+        final String trimPhoneNumber = trimPhoneNumber(phoneNumber);
 
         // pre-validation and formatting with libphonenumber
-        final Phonenumber.PhoneNumber parsedNumber = parsePhoneNumber(phoneNumber, phoneNumberWithoutWhitespace);
+        final Phonenumber.PhoneNumber parsedNumber = parsePhoneNumber(phoneNumber, trimPhoneNumber);
         final String formattedNumber = phoneNumberUtil.format(parsedNumber,
                 PhoneNumberUtil.PhoneNumberFormat.INTERNATIONAL);
 
         // extract primitives from libphonenumber parse result
         final String nationalNumber = String.valueOf(parsedNumber.getNationalNumber());
         final int countryCode = parsedNumber.getCountryCode();
-        final PhoneNumberUtil.PhoneNumberType phoneNumberType = PhoneNumberUtil.getInstance()
-                .getNumberType(parsedNumber);
+        final PhoneNumberType phoneNumberType = getPhoneNumberType(phoneNumber);
 
         // trigger the actual formatting
-        return formatDIN5008(countryCode, nationalNumber, formattedNumber,
-                phoneNumberType.equals(PhoneNumberUtil.PhoneNumberType.FIXED_LINE));
+        String formatDIN5008 = formatDIN5008(countryCode, nationalNumber, formattedNumber,
+                phoneNumberType.equals(PhoneNumberType.FIXED_LINE));
+
+        if (formatDIN5008.length() >= trimPhoneNumber.length()) {
+            return formatDIN5008;
+        } else {
+            throw new PhoneNumberFormattingException(String.format(
+                    "can not format number. the formatted phone number('%s') has less digits than the incoming phone number('%s')",
+                    formatDIN5008, phoneNumber));
+        }
     }
 
 
@@ -152,8 +164,7 @@ public class PhoneNumberFormatter {
      *
      * @throws  PhoneNumberFormattingException  if the phoneNumber cannot be parsed
      */
-    public PhoneNumberUtil.PhoneNumberType getPhoneNumberType(final String phoneNumber)
-        throws PhoneNumberFormattingException {
+    public PhoneNumberType getPhoneNumberType(final String phoneNumber) throws PhoneNumberFormattingException {
 
         Phonenumber.PhoneNumber parsedNumber = parsePhoneNumber(phoneNumber, trimPhoneNumber(phoneNumber));
 
@@ -179,34 +190,32 @@ public class PhoneNumberFormatter {
     private String formatDIN5008(final int countryCode, final String nationalNumber, final String preFormattedNumber,
         final boolean isFixedLine) throws PhoneNumberFormattingException {
 
-        final AreaCodeAndConnectionNumber areaCodeAndConnectionNumber;
+        final NationalNumber areaCodeAndConnectionNumber;
 
         if (isFixedLine) {
-            areaCodeAndConnectionNumber = getAreaCodeAndConnectionNumberFromFixedNumber(preFormattedNumber);
+            areaCodeAndConnectionNumber = getNationalNumberFromFixedNumber(preFormattedNumber);
         } else {
-            areaCodeAndConnectionNumber = getAreaCodeAndConnectionNumberFromMobileNumber(nationalNumber);
+            areaCodeAndConnectionNumber = getNationalNumberFromMobileNumber(nationalNumber);
         }
 
         return chunkAndFormatResult(countryCode, areaCodeAndConnectionNumber);
     }
 
 
-    private AreaCodeAndConnectionNumber getAreaCodeAndConnectionNumberFromMobileNumber(String nationalNumber) {
-
-        AreaCodeAndConnectionNumber areaCodeAndConnectionNumber;
+    private NationalNumber getNationalNumberFromMobileNumber(String nationalNumber) {
 
         if (nationalNumber.length() > 4) { // only for numbers longer than 4 digits
-            areaCodeAndConnectionNumber = new AreaCodeAndConnectionNumber(nationalNumber.substring(0, 3),
-                    nationalNumber.substring(3, nationalNumber.length()).replaceAll("\\D", ""));
-        } else { // for the shorter numbers
-            areaCodeAndConnectionNumber = new AreaCodeAndConnectionNumber("", nationalNumber);
-        }
 
-        return areaCodeAndConnectionNumber;
+            String connectionNumber = nationalNumber.substring(3).replaceAll("\\D", "");
+
+            return new NationalNumber(nationalNumber.substring(0, 3), connectionNumber);
+        } else { // for the shorter numbers
+            return new NationalNumber("", nationalNumber);
+        }
     }
 
 
-    private AreaCodeAndConnectionNumber getAreaCodeAndConnectionNumberFromFixedNumber(String preFormattedNumber)
+    private NationalNumber getNationalNumberFromFixedNumber(String preFormattedNumber)
         throws PhoneNumberFormattingException {
 
         // fist element should be the country code
@@ -216,26 +225,29 @@ public class PhoneNumberFormatter {
             throw new PhoneNumberFormattingException(String.format("Could not extract anything from input number: %s",
                     preFormattedNumber));
         } else if (splittedPreformattedNumber.length <= 2) { // two elements -> take the second element as connection
-            return new AreaCodeAndConnectionNumber("", splittedPreformattedNumber[1].replaceAll("\\D+", ""));
+            return new NationalNumber("", splittedPreformattedNumber[1].replaceAll("\\D+", ""));
         } else { // more than one element -> take the second as area code and the third as connection number (first is country code)
-            return new AreaCodeAndConnectionNumber(preFormattedNumber.split(" ")[1],
-                    splittedPreformattedNumber[2].replaceAll("\\D+", ""));
+
+            String[] connectionNumbers = Arrays.copyOfRange(splittedPreformattedNumber, 2,
+                    splittedPreformattedNumber.length);
+            String connectionNumber = StringUtils.join(connectionNumbers, "");
+
+            return new NationalNumber(splittedPreformattedNumber[1], connectionNumber.replaceAll("\\D+", ""));
         }
     }
 
 
-    private String chunkAndFormatResult(int countryCode, AreaCodeAndConnectionNumber areaCodeAndConnectionNumber) {
+    private String chunkAndFormatResult(int countryCode, NationalNumber nationalNumber) {
 
-        // chunk the number into blocks of 4 digits. the last block can be 1-4 digits
-        final String chunkedConnectionNumber = String.join(" ",
-                areaCodeAndConnectionNumber.connectionNumber.split("(?<=\\G.{4})"));
+        logger().debug("chunk the number:'{} {} {}' into blocks of 4 digits. the last block can be 1-4 digits",
+            countryCode, nationalNumber.areaCode, nationalNumber.connectionNumber);
 
-        if (StringUtils.isBlank(areaCodeAndConnectionNumber.areaCode)) {
+        final String chunkedConnectionNumber = String.join(" ", nationalNumber.connectionNumber.split("(?<=\\G.{4})"));
+
+        if (StringUtils.isBlank(nationalNumber.areaCode)) {
             return String.format("+%d %s", countryCode, chunkedConnectionNumber);
         } else {
-            // target format
-            return String.format("+%d %s %s", countryCode, areaCodeAndConnectionNumber.areaCode,
-                    chunkedConnectionNumber);
+            return String.format("+%d %s %s", countryCode, nationalNumber.areaCode, chunkedConnectionNumber);
         }
     }
 
@@ -249,17 +261,21 @@ public class PhoneNumberFormatter {
      */
     private String trimPhoneNumber(String phoneNumber) {
 
-        String phoneNumberWithoutNewLine = phoneNumber.replaceAll("\\s+", "").replaceAll("\n", "");
+        logger().debug("trim number:'{}' remove spaces, new Lines, '/', '-' and '()'.", phoneNumber);
 
-        return phoneNumberWithoutNewLine.replaceAll("/", "").replaceAll("-", "");
+        String phoneNumberWithoutNewLine = phoneNumber.replaceAll("\\s+", "").replaceAll("\n", "");
+        String phoneNumberWithoutBraces = phoneNumberWithoutNewLine.replaceAll("\\(", "").replaceAll("\\)", "");
+
+        return phoneNumberWithoutBraces.replaceAll("/", "").replaceAll("-", "");
     }
 
-    private class AreaCodeAndConnectionNumber {
+    // National number contains areaCode and connectionNumber
+    private class NationalNumber {
 
         public final String areaCode;
         public final String connectionNumber;
 
-        private AreaCodeAndConnectionNumber(String areaCode, String connectionNumber) {
+        private NationalNumber(String areaCode, String connectionNumber) {
 
             this.areaCode = areaCode;
             this.connectionNumber = connectionNumber;

--- a/src/main/java/net/contargo/types/telephony/validation/PhoneNumberValidationResult.java
+++ b/src/main/java/net/contargo/types/telephony/validation/PhoneNumberValidationResult.java
@@ -1,0 +1,8 @@
+package net.contargo.types.telephony.validation;
+
+public enum PhoneNumberValidationResult {
+
+    ZERO_NUMBER,
+    CAN_NOT_FORMATTED,
+    TO_LARGE
+}

--- a/src/main/java/net/contargo/types/telephony/validation/PhoneNumberValidationResult.java
+++ b/src/main/java/net/contargo/types/telephony/validation/PhoneNumberValidationResult.java
@@ -4,5 +4,5 @@ public enum PhoneNumberValidationResult {
 
     ZERO_NUMBER,
     CAN_NOT_FORMATTED,
-    TO_LARGE
+    TOO_LARGE
 }

--- a/src/main/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidator.java
+++ b/src/main/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidator.java
@@ -40,10 +40,10 @@ public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhone
 
         validationResults.forEach(validationResult -> {
             final String messageTemplate;
-            String propertyName = "phoneNumber";
+            String propertyName = "phone";
 
             if (value.isMobile()) {
-                propertyName = "mobileNumber";
+                propertyName = "mobile";
             }
 
             switch (validationResult) {
@@ -55,8 +55,8 @@ public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhone
                     messageTemplate = "{CAN_NOT_FORMATTED}";
                     break;
 
-                case TO_LARGE:
-                    messageTemplate = "{TO_LARGE}";
+                case TOO_LARGE:
+                    messageTemplate = "{TOO_LARGE}";
                     break;
 
                 default:
@@ -84,7 +84,7 @@ public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhone
             }
 
             if (phoneNumber.getRawPhoneNumber().length() > PHONE_NUMBER_SIZE) {
-                phoneNumberValidationResults.add(PhoneNumberValidationResult.TO_LARGE);
+                phoneNumberValidationResults.add(PhoneNumberValidationResult.TOO_LARGE);
             }
         }
 

--- a/src/main/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidator.java
+++ b/src/main/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidator.java
@@ -14,7 +14,7 @@ import javax.validation.ConstraintValidatorContext;
  * @author  Robin Jayasinghe - jayasinghe@synyx.de
  * @author  Olle Törnström - toernstroem@synyx.de
  */
-public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhoneNumber, String> {
+public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhoneNumber, PhoneNumber> {
 
     @Override
     public void initialize(ValidPhoneNumber a) {
@@ -24,16 +24,14 @@ public class ValidPhoneNumberValidator implements ConstraintValidator<ValidPhone
 
 
     @Override
-    public boolean isValid(String value, ConstraintValidatorContext cvc) {
-
-        PhoneNumber phoneNumber = new PhoneNumber(value);
+    public boolean isValid(PhoneNumber value, ConstraintValidatorContext cvc) {
 
         // We must assume non-null, non-empty is validated elsewhere
-        if (StringUtils.isBlank(value) || phoneNumber.getRawPhoneNumber().trim().isEmpty()) {
+        if (value == null) {
             return true;
         }
 
-        return phoneNumber.isPhoneNumber() && !isPhoneNumberOnlyZeros(phoneNumber);
+        return value.isPhoneNumber() && !isPhoneNumberOnlyZeros(value);
     }
 
 

--- a/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
+++ b/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
@@ -49,6 +49,15 @@ public class PhoneNumberTest {
 
 
     @Test
+    public void ensureFormatsAlgeriaMobile() {
+
+        final PhoneNumber phoneNumber = new PhoneNumber("+213 5 934583");
+
+        assertEquals("+213 593 4583", phoneNumber.getInternationalFormatOfPhoneNumber().get());
+    }
+
+
+    @Test
     public void ensureFormatsLongGermanMobileNumber() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("0171123456789123");
@@ -117,5 +126,14 @@ public class PhoneNumberTest {
 
         assertEquals("+49 234 7855 7433 034", phoneNumber.getInternationalFormatOfPhoneNumber().get());
         assertTrue(phoneNumber.isPhoneNumber());
+    }
+
+
+    @Test
+    public void ensureGettingCorrectFormattedPhoneNumber() {
+
+        final PhoneNumber phoneNumber = new PhoneNumber("+41 713111301");
+
+        assertEquals("+41 71 3111 301", phoneNumber.getInternationalFormatOfPhoneNumber().get());
     }
 }

--- a/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
+++ b/src/test/java/net/contargo/types/telephony/PhoneNumberTest.java
@@ -35,7 +35,7 @@ public class PhoneNumberTest {
     public void ensureInternationalFormattingPhoneNumberFromInvalidInput() {
 
         final PhoneNumber phoneNumber = new PhoneNumber("i321%6&_-?`");
-        assertFalse(phoneNumber.isPhoneNumber());
+        assertFalse(phoneNumber.canBeFormatted());
     }
 
 
@@ -125,7 +125,7 @@ public class PhoneNumberTest {
         final PhoneNumber phoneNumber = new PhoneNumber("a234svljshdf034");
 
         assertEquals("+49 234 7855 7433 034", phoneNumber.getInternationalFormatOfPhoneNumber().get());
-        assertTrue(phoneNumber.isPhoneNumber());
+        assertTrue(phoneNumber.canBeFormatted());
     }
 
 

--- a/src/test/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidatorTest.java
+++ b/src/test/java/net/contargo/types/telephony/validation/ValidPhoneNumberValidatorTest.java
@@ -2,21 +2,35 @@ package net.contargo.types.telephony.validation;
 
 import com.google.i18n.phonenumbers.NumberParseException;
 
+import net.contargo.types.telephony.PhoneNumber;
+
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
+
+import org.junit.Before;
 import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import javax.validation.ConstraintValidatorContext;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import static org.mockito.Matchers.anyString;
+
+import static org.mockito.Mockito.*;
 
 
 public class ValidPhoneNumberValidatorTest {
 
     @Test
-    public void ensureThatValidatorSucceedsWhenFormatterSuceeds() throws NumberParseException {
+    public void ensureThatValidatorSucceedsWhenFormatterSucceeds() {
 
         final ValidPhoneNumberValidator validPhoneNumberValidator = new ValidPhoneNumberValidator();
 
         assertTrue("failed to validate valid phone number successfully",
-            validPhoneNumberValidator.isValid("12344321", null));
+            validPhoneNumberValidator.isValid(new PhoneNumber("12344321"), null));
     }
 
 
@@ -24,15 +38,16 @@ public class ValidPhoneNumberValidatorTest {
     public void ensureThatEmptyStringIsIgnored() {
 
         ValidPhoneNumberValidator sut = new ValidPhoneNumberValidator();
-        assertTrue("Empty phone number (whitespace) must be ignored, as valid", sut.isValid("", null));
+        assertTrue("Empty phone number (whitespace) must be ignored, as valid",
+            sut.isValid(new PhoneNumber(""), null));
     }
 
 
     @Test
-    public void ensureOnlyWhitespaceStringIsIgnored() throws Exception {
+    public void ensureOnlyWhitespaceStringIsIgnored() {
 
         ValidPhoneNumberValidator sut = new ValidPhoneNumberValidator();
-        assertTrue("Empty phone number must be ignored, as valid", sut.isValid("    ", null));
+        assertTrue("Empty phone number must be ignored, as valid", sut.isValid(new PhoneNumber("    "), null));
     }
 
 
@@ -41,14 +56,5 @@ public class ValidPhoneNumberValidatorTest {
 
         final ValidPhoneNumberValidator sut = new ValidPhoneNumberValidator();
         assertTrue("Missing phone number (null) must be ignored, as valid", sut.isValid(null, null));
-    }
-
-
-    @Test
-    public void ensureThatValidatorFailsWhenFormatterThrows() throws NumberParseException {
-
-        final ValidPhoneNumberValidator validPhoneNumberValidator = new ValidPhoneNumberValidator();
-
-        assertFalse("failed to detect invalid phone number", validPhoneNumberValidator.isValid("&§", null));
     }
 }


### PR DESCRIPTION
currently by some numbers the last digits where deleted.
because non german numbers have more spaces in the areacode and connection number
so if they are splitted by the array has a greater length.