### PR TITLE
add reset capability to contactinfo validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Contargo Types
 ===============
 
+## v0.17.4
+
+* Introduce the possibility to reset UniquenessValidator implementations. Reset means that all in-memory data is
+  deleted. Reprovisioning the data lies in the responsibility of the calling code.
+
 ## v0.17.3
 
 * fix PhoneNumberFormatter, the numbers was formatted by the google library and then splitted into country code, areaCode 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>net.contargo</groupId>
     <artifactId>contargo-types</artifactId>
-    <version>0.17.4</version>
+    <version>0.17.5</version>
     <packaging>jar</packaging>
 
     <name>Contargo Types</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>net.contargo</groupId>
     <artifactId>contargo-types</artifactId>
-    <version>0.17.3</version>
+    <version>0.17.4</version>
     <packaging>jar</packaging>
 
     <name>Contargo Types</name>

--- a/src/main/java/net/contargo/types/contactinfo/ContactInfoConsumer.java
+++ b/src/main/java/net/contargo/types/contactinfo/ContactInfoConsumer.java
@@ -22,4 +22,10 @@ public interface ContactInfoConsumer {
 
         // OK
     }
+
+
+    default void reset() {
+
+        // OK
+    }
 }

--- a/src/main/java/net/contargo/types/contactinfo/validation/ReactiveUniquenessValidator.java
+++ b/src/main/java/net/contargo/types/contactinfo/validation/ReactiveUniquenessValidator.java
@@ -111,6 +111,18 @@ public class ReactiveUniquenessValidator implements ContactInfoConsumer, Loggabl
     }
 
 
+    @Override
+    public void reset() {
+
+        userUUIDToMail.clear();
+        userUUIDToMobile.clear();
+        mobileToUserUUIDs.clear();
+        mailToUserUUIDs.clear();
+
+        logger().info("cleared all internal data structures");
+    }
+
+
     private void handleChangedMailAddress(final String newMail, final String userUUID, final String oldMail) {
 
         userUUIDToMail.put(userUUID, newMail);

--- a/src/main/java/net/contargo/types/contactinfo/validation/UniquenessValidator.java
+++ b/src/main/java/net/contargo/types/contactinfo/validation/UniquenessValidator.java
@@ -18,10 +18,4 @@ public interface UniquenessValidator {
 
 
     boolean isMobileUnique(String userUuid, String mobile);
-
-
-    default void reset() {
-
-        // noop
-    }
 }

--- a/src/main/java/net/contargo/types/contactinfo/validation/UniquenessValidator.java
+++ b/src/main/java/net/contargo/types/contactinfo/validation/UniquenessValidator.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 
 /**
- * Implementations of this interface can check whether certain properties in a contact information object are
- * unique within the context of the validators implementation.
+ * Implementations of this interface can check whether certain properties in a contact information object are unique
+ * within the context of the validators implementation.
  */
 public interface UniquenessValidator {
 
@@ -18,4 +18,10 @@ public interface UniquenessValidator {
 
 
     boolean isMobileUnique(String userUuid, String mobile);
+
+
+    default void reset() {
+
+        // noop
+    }
 }

--- a/src/test/java/net/contargo/types/contactinfo/validation/ReactiveUniquenessValidatorTest.java
+++ b/src/test/java/net/contargo/types/contactinfo/validation/ReactiveUniquenessValidatorTest.java
@@ -92,6 +92,26 @@ public class ReactiveUniquenessValidatorTest {
 
 
     @Test
+    public void ensureThatResetClearsAllData() {
+
+        ReactiveUniquenessValidator reactiveUniquenessValidator = new ReactiveUniquenessValidator(
+                new PhoneNumberNormalizer(), new EmailAddressNormalizer());
+
+        consumeColaProfiles(reactiveUniquenessValidator);
+
+        reactiveUniquenessValidator.reset();
+
+        ContactInformation contactInformationWithDuplicateMobile =
+            contactInformationWithDuplicateMobileAfterNormalization();
+        List<ValidationResult> validationResults = reactiveUniquenessValidator.checkUniqueness(
+                contactInformationWithDuplicateMobile);
+
+        assertEquals(0, validationResults.size());
+        // no validation errors since data of validator should be empty
+    }
+
+
+    @Test
     public void ensureThatDuplicateMobileIsDetectedAfterNormalization() {
 
         ReactiveUniquenessValidator reactiveUniquenessValidator = new ReactiveUniquenessValidator(


### PR DESCRIPTION
refs #30446

there might be support cases where an administrator would like to
reset all in-memory data of the validator (and fill it with new data
afterwards). The reset part is done in this commit. The provisioning
of new data must be done by the application that consumes contargo-types
and its validators.