### PR TITLE
optimize validation for null number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 Contargo Types
 ===============
 
+## v0.17.7
+
+* fix regex for the check of number contains only zeros. A number which starts with a + 
+was always not a null number but it should be.
+
+## v0.17.6
+
+* fix ValidPhoneNumberValidator before always returns false if the number was valid. 
+Now is valid is true if the number is correct.
+
 ## v0.17.5
 
 * Optimize ValidPhoneNumberValidator, checking for different constraints such as phone number is zero number, can not be formatted or is to long.

--- a/src/main/java/net/contargo/types/telephony/PhoneNumber.java
+++ b/src/main/java/net/contargo/types/telephony/PhoneNumber.java
@@ -25,7 +25,6 @@ public final class PhoneNumber implements Loggable {
     private Country country;
     private final String rawPhoneNumber;
     private String phoneExtension;
-    private boolean isMobile = false;
 
     public PhoneNumber() {
 
@@ -132,19 +131,7 @@ public final class PhoneNumber implements Loggable {
 
     public boolean containsOnlyZeros() {
 
-        return rawPhoneNumber.matches("0+$");
-    }
-
-
-    public boolean isMobile() {
-
-        return isMobile;
-    }
-
-
-    public void setMobile(boolean mobile) {
-
-        isMobile = mobile;
+        return rawPhoneNumber.matches("^\\+?0+$");
     }
 
 


### PR DESCRIPTION
remove unneeded method for is mobile.
by checking if null number now the number can start with + not only with
a 0.