### PR TITLE
Fix: hibernate-validator dependency leaking into final artefact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- COMMON -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
 
         <!-- VALIDATION -->
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>5.2.4.Final</version>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
         </dependency>
 
         <!-- COMMON -->
@@ -67,6 +67,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>5.2.4.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The hibernate-validator dependency should not be part of the final
artefact, since it is only used to exercise the actual implementation of
the validators in the test cases. When using `contargo-types` with
modern projects, that might include the 6+ version of
hibernate-validator, it leads to actually two versions of the validator
on the final classpath. This is due to Maven groupId change in the
validator package: `org.hibernate:hibernate-validator` became
`org.hibernate.validator:hibernate-validator`.